### PR TITLE
Don't double-prefix awk variables

### DIFF
--- a/scripts/ypinit.in
+++ b/scripts/ypinit.in
@@ -97,7 +97,7 @@ ypinit_master()
 
   echo "We need a few minutes to build the databases..."
   echo "Building $YPMAPDIR/$DOMAIN/ypservers..."
-  cat $YPMAPDIR/ypservers | awk '{print $$0, $$0}' | $YPBINDIR/makedbm - $YPMAPDIR/$DOMAIN/ypservers
+  cat $YPMAPDIR/ypservers | awk '{print $0, $0}' | $YPBINDIR/makedbm - $YPMAPDIR/$DOMAIN/ypservers
 
   if [ $?  -ne 0 ]
   then


### PR DESCRIPTION
Just noticed that when `ypinit`'ing a new domain with multiple servers, only the first server is added to the `ypservers` map. Traced this to the use of double `$$` in the awk command, it's done this way in the Makefile equivalent to prevent `make` interpolating the dollars away but isn't necessary in the script.

It only seems to trigger when one of the servers is specified by an IP address which I'm not sure if that's even legal, but it's what I noticed it with. Minimal example:

```
$ echo -ne '192.0.2.1\nlocalhost\n' | awk '{ print $$0, $0 }'
 192.0.2.1
localhost localhost
```