### PR TITLE
Do not update NIS map when master's version is older

### DIFF
--- a/ypxfr/ypxfr.c
+++ b/ypxfr/ypxfr.c
@@ -482,8 +482,9 @@ ypxfr (char *map, char *source_host, char *source_domain, char *target_domain,
   if (ypproc_order_2 (&req_nokey, &resp_order, clnt_udp) != RPC_SUCCESS)
     {
       log_msg (clnt_sperror (clnt_udp, "ypproc_order_2"));
-      masterOrderNum = time (NULL); /* We set it to the current time.
-                                       So a new map will be always newer. */
+      clnt_destroy (clnt_udp);
+	  return YPXFR_YPERR; /* return error when not possible to
+                            get masterOrder */
     }
   else if (resp_order.status != YP_TRUE)
     {


### PR DESCRIPTION
When the `ypproc_order_2` function returns with value different to `RPC_SUCCESS`, `masterOrderNum` is set to current time. I think that this behavior is wrong, because when `ypproc_order_2` fails, map that is older than current map may be transfered from master to slave.

This situation occurs when part of the communication is lost (may be simulated by dropping 10% of packets). 

The fix makes `ypxfr` to return `YPXFR_YPERR` when getting of `masterOrderNum` fails instead of setting `masterOrderNum` to current time.

More information can be found at https://bugzilla.redhat.com/show_bug.cgi?id=1305137