### PR TITLE
Make cmp_netbuf to handle NULL pointers

### DIFF
--- a/lib/access.c
+++ b/lib/access.c
@@ -151,6 +151,9 @@ copy_netbuf (struct netbuf *src)
 static int
 cmp_netbuf (struct netbuf *nbuf1, struct netbuf *nbuf2)
 {
+  if (nbuf1 == NULL || nbuf2 == NULL)
+    return 1;
+
   if (nbuf1->len != nbuf2->len)
     return 1;
 


### PR DESCRIPTION
When ypserv is run without debug mode activated,
cmp_netbuf(oldaddr, rqhost) may be called with oldaddr
set to NULL pointer. This causes dereferencing of the NULL
pointer and thus undefined bahaviour.

Signed-off-by: Matej Mužila <mmuzila@redhat.com>