### PR TITLE
Fix yppasswdd adding ##username into passwd.adjunct on shell change

### DIFF
--- a/rpc.yppasswdd/update.c
+++ b/rpc.yppasswdd/update.c
@@ -618,7 +618,9 @@ update_files (yppasswd *yppw, int *shadow_changed,
 	      !((yppw->newpw.pw_passwd[0] == 'x' ||
 		 yppw->newpw.pw_passwd[0] == '*') &&
 		yppw->newpw.pw_passwd[1] == '\0') &&
-	      yppw->newpw.pw_passwd[0] != '\0')
+	      yppw->newpw.pw_passwd[0] != '\0' &&
+          !(yppw->newpw.pw_passwd[0] == '#' &&
+            yppw->newpw.pw_passwd[1] == '#'))
 	    {
 	      if (spw)
 		{


### PR DESCRIPTION
This happens when NIS is set up to use `passwd.adjunct` and the client tries to change user's shell by `yppasswd -l` - yppasswdd only checks for regular shadow string when handling the request.
As a result of this the string `##username` overwrites the actual password hash inside `passwd.adjunct` on the server, effectively making the user unable to login anymore.