### PR TITLE
Provide return type for conftest main function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AC_ARG_ENABLE(pie,AS_HELP_STRING([--disable-pie],
 AC_CACHE_CHECK(for -fpie, libc_cv_fpie, [dnl
   cat > conftest.c <<EOF
 int foo;
-main () { return 0;}
+int main () { return 0;}
 EOF
   if test "$USE_PIE" = "yes" &&
 	AC_TRY_COMMAND([${CC-cc} $CFLAGS $CPPFLAGS $LDFLAGS -pie -fpie


### PR DESCRIPTION
Clang will default to treating this to an error in the next release and GCC wants to do the same thing in the near future.